### PR TITLE
Various things

### DIFF
--- a/egs/callhome_diarization/v1/diarization/score_plda.sh
+++ b/egs/callhome_diarization/v1/diarization/score_plda.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-# Copyright    2016  David Snyder
+# Copyright  2016-2018  David Snyder
+#            2017-2018  Matthew Maciejewski
 # Apache 2.0.
 
 # This script computes PLDA scores from pairs of ivectors extracted
@@ -68,7 +68,7 @@ if [ $stage -le 0 ]; then
 fi
 
 if [ $stage -le 1 ]; then
-  echo "$0: combining calibration thresholds across jobs"
+  echo "$0: combining PLDA scores across jobs"
   for j in $(seq $nj); do cat $dir/scores.$j.scp; done >$dir/scores.scp || exit 1;
 fi
 

--- a/egs/callhome_diarization/v1/run.sh
+++ b/egs/callhome_diarization/v1/run.sh
@@ -212,7 +212,7 @@ if [ $stage -le 6 ]; then
     > exp/results/DER_threshold.txt
   der=$(grep -oP 'DIARIZATION\ ERROR\ =\ \K[0-9]+([.][0-9]+)?' \
     exp/results/DER_threshold.txt)
-  # Using supervised calibration, DER: 12.82%
+  # Using supervised calibration, DER: 10.49%
   echo "Using supervised calibration, DER: $der%"
 fi
 
@@ -236,6 +236,6 @@ if [ $stage -le 7 ]; then
     > exp/results/DER_num_spk.txt
   der=$(grep -oP 'DIARIZATION\ ERROR\ =\ \K[0-9]+([.][0-9]+)?' \
     exp/results/DER_num_spk.txt)
-  # Using the oracle number of speakers, DER: 11.42%
+  # Using the oracle number of speakers, DER: 8.65%
   echo "Using the oracle number of speakers, DER: $der%"
 fi

--- a/src/ivector/plda.h
+++ b/src/ivector/plda.h
@@ -133,9 +133,9 @@ class Plda {
 
   /// Apply a transform to the PLDA model.  This is mostly used for
   /// projecting the parameters of the model into a lower dimensional space,
-  /// i.e. pca_transform.NumRows() <= pac_transform.NumCols(), typically for
+  /// i.e. in_transform.NumRows() <= in_transform.NumCols(), typically for
   /// speaker diarization with a PCA transform.
-  void ApplyTransform(const Matrix<double> &pca_transform);
+  void ApplyTransform(const Matrix<double> &in_transform);
 
   int32 Dim() const { return mean_.Dim(); }
   void Write(std::ostream &os, bool binary) const;


### PR DESCRIPTION
+ Changing ivector-plda-scoring-dense to use raw PLDA scores instead of applying the logistic function to them

+ Refactoring agglomerative-clustering so that the class and struct declarations are in the .h file instead of the .cc file. I think this is more standard way to do it in Kaldi.

+ Various cosmetic changes. Removed some unused options. Changed some things that I thought were nonstandard for Kaldi (e.g., delete(foo) vs delete foo or PointerType* foo vs PointerType *foo).
